### PR TITLE
Adding support for transforming bensampo/laravel-enum enums

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,20 +17,21 @@
     ],
     "require" : {
         "php" : "^7.4|^8.0",
+        "ext-json": "*",
         "spatie/typescript-transformer" : "^1.1",
         "illuminate/console" : "^7.0|^8.12"
     },
     "require-dev" : {
-        "orchestra/testbench" : "^5.0|^6.0",
-        "mockery/mockery" : "^1.4",
-        "phpunit/phpunit" : "^9.0",
-        "spatie/enum" : "^3.0",
-        "spatie/temporary-directory" : "^1.2",
+        "bensampo/laravel-enum": "^3.2",
+        "mockery/mockery": "^1.4",
+        "orchestra/testbench": "^5.0|^6.0",
+        "phpunit/phpunit": "^9.0",
+        "spatie/data-transfer-object": "^2.0",
+        "spatie/enum": "^3.0",
+        "spatie/laravel-model-states": "^1.6|^2.0",
         "spatie/phpunit-snapshot-assertions": "^4.2",
-        "spatie/data-transfer-object" : "^2.0",
-        "spatie/laravel-model-states" : "^1.6|^2.0",
+        "spatie/temporary-directory": "^1.2",
         "vimeo/psalm": "^4.2"
-
     },
     "repositories": [
         {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "illuminate/console" : "^7.0|^8.12"
     },
     "require-dev" : {
-        "bensampo/laravel-enum": "^3.2",
+        "bensampo/laravel-enum": "^2.0|^3.0",
         "mockery/mockery": "^1.4",
         "orchestra/testbench": "^5.0|^6.0",
         "phpunit/phpunit": "^9.0",

--- a/config/typescript-transformer.php
+++ b/config/typescript-transformer.php
@@ -45,6 +45,7 @@ return [
         Spatie\LaravelTypeScriptTransformer\Transformers\SpatieStateTransformer::class,
         Spatie\TypeScriptTransformer\Transformers\SpatieEnumTransformer::class,
         Spatie\TypeScriptTransformer\Transformers\DtoTransformer::class,
+        Spatie\LaravelTypeScriptTransformer\Transformers\BenSampoLaravelEnumTransformer::class,
     ],
 
     /*

--- a/src/Transformers/BenSampoLaravelEnumTransformer.php
+++ b/src/Transformers/BenSampoLaravelEnumTransformer.php
@@ -30,7 +30,7 @@ class BenSampoLaravelEnumTransformer implements Transformer
         $enum = $class->getName();
 
         $options = array_map(
-            fn($key) => "  {$key} = ".json_encode($enum::getValue($key)).",",
+            fn ($key) => "  {$key} = " . json_encode($enum::getValue($key)) . ",",
             $enum::getKeys()
         );
 

--- a/src/Transformers/BenSampoLaravelEnumTransformer.php
+++ b/src/Transformers/BenSampoLaravelEnumTransformer.php
@@ -1,0 +1,39 @@
+<?php
+
+
+namespace Spatie\LaravelTypeScriptTransformer\Transformers;
+
+use BenSampo\Enum\Enum;
+use ReflectionClass;
+use Spatie\TypeScriptTransformer\Structures\TransformedType;
+use Spatie\TypeScriptTransformer\Transformers\Transformer;
+
+class BenSampoLaravelEnumTransformer implements Transformer
+{
+    public function canTransform(ReflectionClass $class): bool
+    {
+        return $class->isSubclassOf(Enum::class);
+    }
+
+    public function transform(ReflectionClass $class, string $name): TransformedType
+    {
+        return TransformedType::create(
+            $class,
+            $name,
+            "export enum {$name} {" . PHP_EOL . $this->resolveOptions($class) . PHP_EOL . "}"
+        );
+    }
+
+    private function resolveOptions(ReflectionClass $class): string
+    {
+        /** @var Enum $enum */
+        $enum = $class->getName();
+
+        $options = array_map(
+            fn($key) => "  {$key} = ".json_encode($enum::getValue($key)).",",
+            $enum::getKeys()
+        );
+
+        return implode(PHP_EOL, $options);
+    }
+}

--- a/tests/Transformers/BenSampoLaravelEnumTransformerTest.php
+++ b/tests/Transformers/BenSampoLaravelEnumTransformerTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Spatie\LaravelTypeScriptTransformer\Tests\Transformers;
+
+use BenSampo\Enum\Enum;
+use ReflectionClass;
+use Spatie\LaravelTypeScriptTransformer\Tests\TestCase;
+use Spatie\LaravelTypeScriptTransformer\Transformers\BenSampoLaravelEnumTransformer;
+use Spatie\Snapshots\MatchesSnapshots;
+
+class BenSampoLaravelEnumTransformerTest extends TestCase
+{
+    use MatchesSnapshots;
+
+    private BenSampoLaravelEnumTransformer $transformer;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->transformer = new BenSampoLaravelEnumTransformer();
+    }
+
+    /** @test */
+    public function it_will_check_if_an_enum_can_be_transformed()
+    {
+        $enum = new class(10) extends Enum {
+            public const ADMIN = 10;
+            public const USER = 20;
+        };
+
+        $noEnum = new class {
+        };
+
+        $this->assertTrue($this->transformer->canTransform(new ReflectionClass($enum)));
+        $this->assertFalse($this->transformer->canTransform(new ReflectionClass($noEnum)));
+    }
+
+    /** @test */
+    public function it_can_transform_an_enum()
+    {
+        $enum = new class('foobar') extends Enum {
+            public const ADMIN = 10;
+            public const USER = 20;
+            public const STRING_USER = 'foobar';
+        };
+
+        $type = $this->transformer->transform(new ReflectionClass($enum), 'Enum');
+
+        $this->assertMatchesSnapshot($type->transformed);
+        $this->assertTrue($type->missingSymbols->isEmpty());
+    }
+
+
+}

--- a/tests/Transformers/BenSampoLaravelEnumTransformerTest.php
+++ b/tests/Transformers/BenSampoLaravelEnumTransformerTest.php
@@ -50,6 +50,4 @@ class BenSampoLaravelEnumTransformerTest extends TestCase
         $this->assertMatchesSnapshot($type->transformed);
         $this->assertTrue($type->missingSymbols->isEmpty());
     }
-
-
 }

--- a/tests/Transformers/__snapshots__/BenSampoLaravelEnumTransformerTest__it_can_transform_an_enum__1.txt
+++ b/tests/Transformers/__snapshots__/BenSampoLaravelEnumTransformerTest__it_can_transform_an_enum__1.txt
@@ -1,0 +1,5 @@
+export enum Enum {
+  ADMIN = 10,
+  USER = 20,
+  STRING_USER = "foobar",
+}


### PR DESCRIPTION
Adding support for transforming (BenSampo/laravel-enum)[https://github.com/BenSampo/laravel-enum] based Enums, this implementation was based on the `MyclabsEnumTransformer` with some minor difference to the outputted format.