### PR TITLE
Add force option to command

### DIFF
--- a/src/Commands/TypeScriptTransformCommand.php
+++ b/src/Commands/TypeScriptTransformCommand.php
@@ -15,6 +15,7 @@ class TypeScriptTransformCommand extends Command
     use ConfirmableTrait;
 
     protected $signature = 'typescript:transform
+                            {--force : Force the operation to run when in production}
                             {--path= : Specify a path with classes to transform}
                             {--output= : Use another file to output}
                             {--format : Use Prettier to format the output}';


### PR DESCRIPTION
When running this command in production, you get the warning from the `Confirmable` trait.

In a headless environment you want to skip this warning by adding the `--force` option, but the command doesn't have this option.