### PR TITLE
Replace CarbonInterface with a string

### DIFF
--- a/config/typescript-transformer.php
+++ b/config/typescript-transformer.php
@@ -42,6 +42,7 @@ return [
     'default_type_replacements' => [
         DateTime::class => 'string',
         DateTimeImmutable::class => 'string',
+        Carbon\CarbonInterface::class => 'string',
         Carbon\CarbonImmutable::class => 'string',
         Carbon\Carbon::class => 'string',
     ],


### PR DESCRIPTION
In Data object, you might want to allow using `CarbonInterface`, like:
```php

class SomeData extends \Spatie\LaravelData\Data
{

public function __construct(
    ...
    CarbonInterface $somethingHappenedAt,
    ....
) {}
```

This will be casted to a _string_ by default. So I think it would be good idea to include by default this, and to have `string` representation (instead of `any`) in Typescript for this property.