### PR TITLE
Use Laravel typescript transformer by default

### DIFF
--- a/config/typescript-transformer.php
+++ b/config/typescript-transformer.php
@@ -30,7 +30,7 @@ return [
         Spatie\LaravelTypeScriptTransformer\Transformers\SpatieStateTransformer::class,
         Spatie\TypeScriptTransformer\Transformers\EnumTransformer::class,
         Spatie\TypeScriptTransformer\Transformers\SpatieEnumTransformer::class,
-        Spatie\TypeScriptTransformer\Transformers\DtoTransformer::class,
+        Spatie\LaravelTypeScriptTransformer\Transformers\DtoTransformer::class,
     ],
 
     /*


### PR DESCRIPTION
The `LaravelCollectionTypeProcessor` was not being called in the default config for this package, I'm assuming this was a mistake?