### PR TITLE
Let artisan handle the exceptions

### DIFF
--- a/src/Commands/TypeScriptTransformCommand.php
+++ b/src/Commands/TypeScriptTransformCommand.php
@@ -41,15 +41,9 @@ class TypeScriptTransformCommand extends Command
 
         $transformer = new TypeScriptTransformer($config);
 
-        try {
-            $this->ensureConfiguredCorrectly();
+        $this->ensureConfiguredCorrectly();
 
-            $collection = $transformer->transform();
-        } catch (Exception $exception) {
-            $this->error($exception->getMessage());
-
-            return 1;
-        }
+        $collection = $transformer->transform();
 
         $this->table(
             ['PHP class', 'TypeScript entity'],


### PR DESCRIPTION
The error message otherwise gives no indication to track the error

Whereas artisan's builtin mechanism to print exceptions does
![image](https://github.com/spatie/laravel-typescript-transformer/assets/6115458/e6241070-048b-45a6-8017-13956af13e4e)
