### PR TITLE
ModelTransformer

### DIFF
--- a/src/Transformers/ModelTransformer.php
+++ b/src/Transformers/ModelTransformer.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Spatie\LaravelTypeScriptTransformer\Transformers;
+
+use Spatie\TypeScriptTransformer\Structures\TransformedType;
+
+use DB;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
+use ReflectionClass;
+
+/**
+ * A Transformer that generates Typescript definitions for a Model by inspecting the DB Schema
+ */
+class ModelTransformer implements Transformer
+{
+    public function transform(ReflectionClass $class, string $name): ?TransformedType
+    {
+        if (!is_subclass_of($class->name, Model::class)) {
+            return null;
+        }
+
+        /** @var Model $modelInstance */
+        $modelInstance = $class->newInstanceWithoutConstructor();
+
+        $table = $modelInstance->getTable();
+        $columns = Schema::getColumnListing($table);
+
+        $hidden = $modelInstance->getHidden();
+
+        $serializedColumns = array_diff($columns, $hidden);
+
+        $column_defs = collect(DB::select("
+            SELECT column_name, is_nullable, data_type
+            FROM information_schema.columns
+            WHERE table_name = '$table';
+        "));
+
+        $model_attrs = [];
+        foreach ($serializedColumns as $column) {
+            $def = $column_defs->firstWhere('column_name', $column);
+            $is_nullable = $def->is_nullable == 'YES';
+            $column_type = $this->mapToTypeScriptType($def->data_type);
+            $attr_type = "$column: $column_type";
+
+            if ($is_nullable) {
+                $attr_type .= ' | null';
+            }
+
+            $model_attrs[] = $attr_type;
+        }
+
+        return TransformedType::create(
+            $class,
+            $name,
+            '{'.implode("\n", $model_attrs).'}',
+        );
+    }
+
+    /**
+     *  Map column types to TypeScript types
+     */
+    private function mapToTypeScriptType(string $data_type): string
+    {
+        return match ($data_type) {
+            'string', 'text', 'varchar', 'character varying' => 'string',
+            'integer', 'bigint', 'int8' => 'number',
+            'float', 'double', 'decimal' => 'number',
+            'boolean', 'bool' => 'boolean',
+            'date', 'datetime', 'timestamp', 'timestamp without time zone' => 'Date',
+            default => dd($columnType), // Fallback for other types
+        };
+    }
+}


### PR DESCRIPTION
# !!Note for Reviewers!!

This is NOT a ready PR. The only reason I didn't make it is a draft is so it would get immediate attention.

Since Issues/Discussions are turned off, I'm basically using this as a place to suggest the idea and provide a prototype. 

I am using this class in my own project but I haven't put any effort into testing it's robustness. I'll highlight some areas that I'm particularly unsure about in the PR comments.

Right now, I'm not looking for approval of the _code_ but approval of the _idea_, along with any suggestions you might have for implementation.

# `ModelTransformer`

Introduces a default Transformer for generating TS definitions for Eloquent models.

## Background
I am using Inertia with Vue and Typescript in a Laravel app. 

Laravel gracefully handles serializing models to JSON. It automatically includes the database columns, and has several ways to specify which columns should or should not be serialized. 

## Problem
Annotating Eloquent models with @typescript doesn't generate usable types.

There are two main problems:
1. It doesn't know about the database columns
2. It adds extra properties that don't actually get serialized to JSON

<img width="312" alt="image" src="https://github.com/user-attachments/assets/b33bc3c5-1d33-42f3-98d9-318e1c908a3f">

Surprisingly (to me) even the `@property` annotation doesn't add those fields to the Typescript definition. Even if it did, that wouldn't be an appropriate solution, as it would not take the models `$hidden` or `$visible` attributes into consideration.

## Current Workarounds

**The first option is to just manually write types.** Not the worst thing, but it's definitely not ideal. Types like this tend to get out of date. 

**An alternative is to create a Data object using `laravel-data` and generate the types for that.** I love that library, but creating Data objects that just mirror the models 1-to-1 is a waste. That pattern is most appropriate when the frontend/api needs to return a Data shape that doesn't match the Eloquent models, or as an alternative to FormRequests. Note: It also adds a slight bit of performance overhead, which isn't a _big_ deal but has been a concern for some of our endpoints.

## Proposed Solution
Introduce a new `ModelTransformer` that generates Typescript definitions for Eloquent models with zero additional configuration/annotations required.

Accomplishes this task by inspecting both the Database Schema and the Model itself.

Here's a rough flow of what the 
- Get the columns + data type from the DB Schema for the model's table.
- Use the Model's `visible`/`hidden` attributes to select the subset of fields to generate types for.
- Use the Column `data_type`  to determine what TS type the field should have
- Check for any Model `casts` and update the TS types as needed

## Uncertainties
- [ ]  Is the use of the `DB` and `Schema` facades appropriate for this library?
- [x]  Does the Schema facade return consistent column data_types for each kind of database?
- [ ]  How do the `$visible` and `$hidden` attributes interact with each other when serializing models?

