### PR TITLE
Use service container to resolve TypescriptTransformer

### DIFF
--- a/src/Commands/TypeScriptTransformCommand.php
+++ b/src/Commands/TypeScriptTransformCommand.php
@@ -39,7 +39,9 @@ class TypeScriptTransformCommand extends Command
             $config->formatter(PrettierFormatter::class);
         }
 
-        $transformer = new TypeScriptTransformer($config);
+        $transformer = app()->make(TypeScriptTransformer::class, [
+            'config' => $config,
+        ]);
 
         try {
             $this->ensureConfiguredCorrectly();


### PR DESCRIPTION
This change allows for more flexibility by extending and swapping the typescript transformer without re-implementing the command. 