### PR TITLE
Add `--check-only` option for `typescript:transform` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,30 @@ export type User = {
 
 Want to know more? You can find the documentation [here](https://docs.spatie.be/typescript-transformer/v2/introduction/).
 
+## GitHub Actions Integration
+
+The `--check-only` flag for the `typescript:transform` artisan command verifies whether your TypeScript files are up to date, without making any changes to them. Use this in your GitHub Actions workflow to ensure that your TypeScript files are always in sync with your PHP code.
+
+```yaml
+name: Check TypeScript Files
+on: [push, pull_request] # Use any trigger you prefer
+
+jobs:
+  check-typescript:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2' # Specify your PHP version
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist --optimize-autoloader
+      - name: Check TypeScript files
+        run: php artisan typescript:transform --check-only
+```
+
 ## Testing
 
 ``` bash

--- a/src/Commands/TypeScriptTransformCommand.php
+++ b/src/Commands/TypeScriptTransformCommand.php
@@ -5,6 +5,7 @@ namespace Spatie\LaravelTypeScriptTransformer\Commands;
 use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
+use Spatie\TemporaryDirectory\TemporaryDirectory;
 use Spatie\TypeScriptTransformer\Formatters\PrettierFormatter;
 use Spatie\TypeScriptTransformer\Structures\TransformedType;
 use Spatie\TypeScriptTransformer\TypeScriptTransformer;
@@ -18,7 +19,8 @@ class TypeScriptTransformCommand extends Command
                             {--force : Force the operation to run when in production}
                             {--path= : Specify a path with classes to transform}
                             {--output= : Use another file to output}
-                            {--format : Use Prettier to format the output}';
+                            {--format : Use Prettier to format the output}
+                            {--check-only : Check whether the output file is up to date}';
 
     protected $description = 'Map PHP structures to TypeScript';
 
@@ -37,6 +39,10 @@ class TypeScriptTransformCommand extends Command
 
         if ($this->option('format')) {
             $config->formatter(PrettierFormatter::class);
+        }
+
+        if ($this->option('check-only')) {
+            return $this->executeCheckOnly($config);
         }
 
         $transformer = app()->make(TypeScriptTransformer::class, [
@@ -96,5 +102,48 @@ class TypeScriptTransformCommand extends Command
         if (config()->has('typescript-transformer.searching_path')) {
             throw new Exception('In v2 of laravel-typescript-transformer the `searching_path` key within the typescript-transformer.php config file is renamed to `auto_discover_types`');
         }
+    }
+
+    private function executeCheckOnly(TypeScriptTransformerConfig $config): int
+    {
+        $tempDirectory = (new TemporaryDirectory())->create();
+        $tempOutputFile = $tempDirectory->path('temp.d.ts');
+        $prevOutputFile = $this->resolveOutputFile() ?? $config->getOutputFile();
+
+        $transformer = app()->make(TypeScriptTransformer::class, [
+            'config' => $config->outputFile($tempOutputFile),
+        ]);
+
+        try {
+            $this->ensureConfiguredCorrectly();
+        } catch (Exception $exception) {
+            $this->error($exception->getMessage());
+
+            return 1;
+        }
+
+        $transformer->transform();
+
+        $tempOutputFileContent = ! is_null($tempOutputFile) && file_exists($tempOutputFile)
+            ? file_get_contents($tempOutputFile)
+            : '';
+
+        $prevOutputFileContent = ! is_null($prevOutputFile) && file_exists($prevOutputFile)
+            ? file_get_contents($prevOutputFile)
+            : '';
+
+        $tempDirectory->delete();
+
+        if (preg_replace('/\s+/', '', trim($tempOutputFileContent)) !== preg_replace('/\s+/', '', trim($prevOutputFileContent))) {
+            $this->error('Output file is not up to date');
+            $this->line('Previous output file:');
+            $this->line($prevOutputFileContent);
+            $this->line('Current output file:');
+            $this->line($tempOutputFileContent);
+            return 1;
+        }
+
+        $this->info('No changes detected, output file is up to date');
+        return 0;
     }
 }

--- a/tests/TypescriptTransformerTest.php
+++ b/tests/TypescriptTransformerTest.php
@@ -44,7 +44,7 @@ it('can define the input path', function () {
     config()->set('typescript-transformer.searching_paths', __DIR__ . '/FakeClasses');
     config()->set('typescript-transformer.output_file', $this->temporaryDirectory->path('index.d.ts'));
 
-    $this->artisan('typescript:transform --path='. __DIR__ . '/FakeClasses')->assertExitCode(0);
+    $this->artisan('typescript:transform --path=' . __DIR__ . '/FakeClasses')->assertExitCode(0);
 
     expect($this->temporaryDirectory->path('index.d.ts'))->toMatchFileSnapshot();
 });
@@ -71,4 +71,76 @@ it('can define the relative output path', function () {
     $this->artisan('typescript:transform --path=FakeClasses --output=other-index.d.ts')->assertExitCode(0);
 
     expect($this->temporaryDirectory->path('resources/other-index.d.ts'))->toMatchFileSnapshot();
+});
+
+it('can check if output file is up to date without mutating it', function () {
+    config()->set('typescript-transformer.auto_discover_types', __DIR__ . '/FakeClasses');
+
+    $outputFile = $this->temporaryDirectory->path('index.d.ts');
+    config()->set('typescript-transformer.output_file', $outputFile);
+
+    $this->artisan('typescript:transform')->assertExitCode(0);
+
+    $originalContent = file_get_contents($outputFile);
+    $originalModTime = filemtime($outputFile);
+
+    $this->artisan('typescript:transform --check-only')->assertExitCode(0);
+
+    expect(file_get_contents($outputFile))->toBe($originalContent);
+    expect(filemtime($outputFile))->toBe($originalModTime);
+});
+
+it('detects when output file is not up to date', function () {
+    config()->set('typescript-transformer.auto_discover_types', __DIR__ . '/FakeClasses');
+
+    $outputFile = $this->temporaryDirectory->path('index.d.ts');
+    config()->set('typescript-transformer.output_file', $outputFile);
+
+    file_put_contents($outputFile, '// Outdated content');
+    $originalContent = file_get_contents($outputFile);
+    $originalModTime = filemtime($outputFile);
+
+    $this->artisan('typescript:transform --check-only')->assertExitCode(1);
+
+    expect(file_get_contents($outputFile))->toBe($originalContent);
+    expect(filemtime($outputFile))->toBe($originalModTime);
+});
+
+it('handles missing output file in check-only mode', function () {
+    config()->set('typescript-transformer.auto_discover_types', __DIR__ . '/FakeClasses');
+
+    $outputFile = $this->temporaryDirectory->path('index.d.ts');
+    config()->set('typescript-transformer.output_file', $outputFile);
+
+    if (file_exists($outputFile)) {
+        unlink($outputFile);
+    }
+
+    $this->artisan('typescript:transform --check-only')->assertExitCode(1);
+
+    expect(file_exists($outputFile))->toBeFalse();
+});
+
+it('does not change any files in check-only mode', function () {
+    config()->set('typescript-transformer.auto_discover_types', __DIR__ . '/FakeClasses');
+
+    $outputFile = $this->temporaryDirectory->path('index.d.ts');
+    config()->set('typescript-transformer.output_file', $outputFile);
+
+    // Create an extra file to ensure it's not touched
+    $extraFile = $this->temporaryDirectory->path('extra.txt');
+    file_put_contents($outputFile, '// Initial content');
+    file_put_contents($extraFile, 'extra');
+
+    $originalOutputContent = file_get_contents($outputFile);
+    $originalOutputModTime = filemtime($outputFile);
+    $originalExtraContent = file_get_contents($extraFile);
+    $originalExtraModTime = filemtime($extraFile);
+
+    $this->artisan('typescript:transform --check-only')->assertExitCode(1);
+
+    expect(file_get_contents($outputFile))->toBe($originalOutputContent);
+    expect(filemtime($outputFile))->toBe($originalOutputModTime);
+    expect(file_get_contents($extraFile))->toBe($originalExtraContent);
+    expect(filemtime($extraFile))->toBe($originalExtraModTime);
 });


### PR DESCRIPTION
Hello 👋,

This PR introduces a `--check-only` option to the `typescript:transform` Artisan command. This flag allows developers to **verify whether the generated TypeScript output is up to date without modifying any files**.

## ✨ What's New

- ✅ Added `--check-only` option to `typescript:transform`
- 🧪 Added full test coverage:
  - Ensures no changes when output is up to date
  - Detects outdated or missing output files
  - Validates that no files are mutated
- 📘 Updated `README.md` with usage instructions and GitHub Actions example for CI integration

## 🔍 Use Case

This feature is especially useful in CI environments to ensure that generated TypeScript definitions are always committed and up to date. Here's a sample use case in a GitHub Actions workflow:

```yaml
- name: Check TypeScript files
  run: php artisan typescript:transform --check-only
```

If the output is outdated or missing, the command will exit with code `1`, causing the workflow to fail — making it easy to catch mismatches early.