### PR TITLE
fix: laravel data MapName attribute output

### DIFF
--- a/src/LaravelData/ClassPropertyProcessors/DataClassPropertyProcessor.php
+++ b/src/LaravelData/ClassPropertyProcessors/DataClassPropertyProcessor.php
@@ -66,9 +66,9 @@ class DataClassPropertyProcessor implements ClassPropertyProcessor
             );
         }
 
-        if (! empty($mapNodes) && $mapNodes[0]->getArgument('output') !== null) {
+        if (! empty($mapNodes)) {
             $property->name = new TypeScriptIdentifier(
-                $this->resolveOutputName($mapNodes[0]->getArgument('output'), $propertyName)
+                $this->resolveOutputName($mapNodes[0]->getArgument('output') ?? $mapNodes[0]->getArgument('input'), $propertyName)
             );
         }
 


### PR DESCRIPTION
There is currently an issue where Laravel Data classes/properties using the `#[MapName]` attribute output the original property name if no output argument is specified.

If you have the following class:

```
#[MapName(SnakeCaseMapper::class)]
class UserData extends Data
{
    public function __construct(
        public readonly string $firstName,
    ) {}
}
```

The typescript outputed would be:

```ts
 export type UserData = {
    readonly firstName: string;
}
```

Instead of the expected:

```ts
 export type UserData = {
    readonly first_name: string;
}
```

This is caused by the current implementation expecting an output argument.