### PR TITLE
Fix: GlobalNamespaceWriter produces broken path when given an absolute path

### DIFF
--- a/stubs/TypeScriptTransformerServiceProvider.stub
+++ b/stubs/TypeScriptTransformerServiceProvider.stub
@@ -17,7 +17,7 @@ class TypeScriptTransformerServiceProvider extends BaseTypeScriptTransformerServ
             ->transformer(AttributedClassTransformer::class)
             ->transformer(EnumTransformer::class)
             ->transformDirectories(app_path())
-            ->writer(new GlobalNamespaceWriter(resource_path('types/generated.d.ts')))
+            ->writer(new GlobalNamespaceWriter('generated.d.ts'))
             ->formatter(PrettierFormatter::class);
     }
 }


### PR DESCRIPTION
## Bug
When passing an absolute path to `GlobalNamespaceWriter`, the generated file ends up in a wrong nested path:
resources/js/generated/home/user/project/resources/types/generated.d.ts
Instead of the expected:
resources/js/generated/generated.d.ts
## Cause
`WriteFilesAction::writeFile()` concatenates `outputDirectory` + `/` + `writer->path`:

in [WriteFilesAction::writeFile()](https://github.com/spatie/typescript-transformer/blob/772dde6e154b491365be0842bca76363c2a9c517/src/Actions/WriteFilesAction.php#L32)
```php
$fullPath = $this->config->outputDirectory . DIRECTORY_SEPARATOR . $file->path;
```
When `writer->path` is an absolute path (like `resource_path('types/generated.d.ts')`), the result is a **broken doubled path**.

## Fix
Pass a relative filename instead of an absolute path.

The file will now correctly be written to` {outputDirectory}/generated.d.ts`.