### PR TITLE
Fix null-byte crash in route watcher when using filters

### DIFF
--- a/src/Commands/RoutesDumpCommand.php
+++ b/src/Commands/RoutesDumpCommand.php
@@ -24,7 +24,7 @@ class RoutesDumpCommand extends Command
 
         $routeCollection = $resolveRouteCollectionAction->execute(
             includeRouteClosures: $this->option('include-route-closures'),
-            filters: $filters === null ? [] : unserialize($filters)
+            filters: $filters === null ? [] : unserialize(base64_decode($filters))
         );
 
         $this->output->write(serialize($routeCollection));

--- a/src/TransformedProviders/LaravelRouterTransformedProvider.php
+++ b/src/TransformedProviders/LaravelRouterTransformedProvider.php
@@ -88,7 +88,7 @@ abstract class LaravelRouterTransformedProvider implements TransformedProvider, 
             'php',
             'artisan',
             'typescript:dump-routes',
-            $this->filters ? serialize($this->filters) : 'null',
+            $this->filters ? base64_encode(serialize($this->filters)) : 'null',
             $this->includeRouteClosures ? '--include-route-closures' : '',
         ];
 


### PR DESCRIPTION
## Summary

Watching routes with any `RouteFilter` configured crashes with `Command array element 4 contains a null byte`.

`LaravelRouterTransformedProvider::handleWatchEvent` shells out to `typescript:dump-routes` with `serialize($this->filters)` as a CLI argument. PHP's `serialize()` encodes protected/private properties with `\0*\0` / `\0Class\0` markers, and Symfony Process rejects any command array element containing a null byte. Every shipped filter (`NamedRouteFilter`, `ControllerRouteFilter`, `ClosureRouteFilter`) hits this because they all use protected properties.

Fix: base64-encode the serialized payload before passing it across the process boundary, decode it in `RoutesDumpCommand`.

Refs spatie/typescript-transformer#147