### PR TITLE
Honor laravel-data name_mapping_strategy.output config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan" : "^2.0",
-        "spatie/laravel-data": "^4.0",
+        "spatie/laravel-data": "^4.10",
         "orchestra/testbench" : "^9.0|^10.0|^11.0"
     },
     "autoload" : {

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan" : "^2.0",
-        "spatie/laravel-data": "^4.10",
+        "spatie/laravel-data": "^4.0",
         "orchestra/testbench" : "^9.0|^10.0|^11.0"
     },
     "autoload" : {

--- a/src/LaravelData/ClassPropertyProcessors/DataClassPropertyProcessor.php
+++ b/src/LaravelData/ClassPropertyProcessors/DataClassPropertyProcessor.php
@@ -124,7 +124,7 @@ class DataClassPropertyProcessor implements ClassPropertyProcessor
         }
 
         if (is_string($value) && is_subclass_of($value, NameMapper::class)) {
-            return app($value)->map($propertyName);
+            return (new $value())->map($propertyName);
         }
 
         return $value;

--- a/src/LaravelData/ClassPropertyProcessors/DataClassPropertyProcessor.php
+++ b/src/LaravelData/ClassPropertyProcessors/DataClassPropertyProcessor.php
@@ -21,6 +21,9 @@ use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptUnion;
 
 class DataClassPropertyProcessor implements ClassPropertyProcessor
 {
+    /** @var array<class-string<NameMapper>, NameMapper> */
+    protected static array $mappers = [];
+
     protected array $lazyTypes = [
         'Spatie\LaravelData\Lazy',
         'Spatie\LaravelData\Support\Lazy\ClosureLazy',
@@ -124,7 +127,7 @@ class DataClassPropertyProcessor implements ClassPropertyProcessor
         }
 
         if (is_string($value) && is_subclass_of($value, NameMapper::class)) {
-            return (new $value())->map($propertyName);
+            return (self::$mappers[$value] ??= new $value())->map($propertyName);
         }
 
         return $value;

--- a/src/LaravelData/ClassPropertyProcessors/DataClassPropertyProcessor.php
+++ b/src/LaravelData/ClassPropertyProcessors/DataClassPropertyProcessor.php
@@ -81,7 +81,7 @@ class DataClassPropertyProcessor implements ClassPropertyProcessor
 
     protected function resolveOutputMappedName(PhpPropertyNode $phpPropertyNode): string|int|null
     {
-        $className = $phpPropertyNode->getDeclaringClass()->reflection->getName();
+        $className = $phpPropertyNode->getDeclaringClass()->getName();
         $propertyName = $phpPropertyNode->getName();
 
         $dataProperty = $this->dataConfig->getDataClass($className)->properties[$propertyName] ?? null;

--- a/src/LaravelData/ClassPropertyProcessors/DataClassPropertyProcessor.php
+++ b/src/LaravelData/ClassPropertyProcessors/DataClassPropertyProcessor.php
@@ -4,9 +4,12 @@ namespace Spatie\LaravelTypeScriptTransformer\LaravelData\ClassPropertyProcessor
 
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use Spatie\LaravelData\Attributes\Hidden as DataHidden;
+use Spatie\LaravelData\Attributes\MapName;
+use Spatie\LaravelData\Attributes\MapOutputName;
+use Spatie\LaravelData\Mappers\NameMapper;
 use Spatie\LaravelData\Optional;
-use Spatie\LaravelData\Support\DataConfig;
 use Spatie\TypeScriptTransformer\Attributes\Hidden;
+use Spatie\TypeScriptTransformer\PhpNodes\PhpAttributeNode;
 use Spatie\TypeScriptTransformer\PhpNodes\PhpPropertyNode;
 use Spatie\TypeScriptTransformer\References\ClassStringReference;
 use Spatie\TypeScriptTransformer\Transformers\ClassPropertyProcessors\ClassPropertyProcessor;
@@ -30,7 +33,6 @@ class DataClassPropertyProcessor implements ClassPropertyProcessor
     ];
 
     public function __construct(
-        protected DataConfig $dataConfig,
         protected array $customLazyTypes = [],
         protected bool $nullableAsOptional = false,
     ) {
@@ -46,10 +48,14 @@ class DataClassPropertyProcessor implements ClassPropertyProcessor
             return null;
         }
 
-        $outputMappedName = $this->resolveOutputMappedName($phpPropertyNode);
+        $propertyName = $phpPropertyNode->getName();
 
-        if ($outputMappedName !== null) {
-            $property->name = new TypeScriptIdentifier($outputMappedName);
+        $outputMapper = $this->resolveOutputMapper($phpPropertyNode);
+
+        if ($outputMapper !== null) {
+            $property->name = new TypeScriptIdentifier(
+                $this->applyOutputMapper($outputMapper, $propertyName)
+            );
         }
 
         if (! $property->type instanceof TypeScriptUnion) {
@@ -79,14 +85,49 @@ class DataClassPropertyProcessor implements ClassPropertyProcessor
         return $property;
     }
 
-    protected function resolveOutputMappedName(PhpPropertyNode $phpPropertyNode): string|int|null
+    protected function resolveOutputMapper(PhpPropertyNode $phpPropertyNode): mixed
     {
-        $className = $phpPropertyNode->getDeclaringClass()->getName();
-        $propertyName = $phpPropertyNode->getName();
+        if ($mapper = $this->extractMapperFromAttributes($phpPropertyNode->getAttributes(MapOutputName::class), $phpPropertyNode->getAttributes(MapName::class))) {
+            return $mapper;
+        }
 
-        $dataProperty = $this->dataConfig->getDataClass($className)->properties[$propertyName] ?? null;
+        $classNode = $phpPropertyNode->getDeclaringClass();
 
-        return $dataProperty?->outputMappedName;
+        if ($mapper = $this->extractMapperFromAttributes($classNode->getAttributes(MapOutputName::class), $classNode->getAttributes(MapName::class))) {
+            return $mapper;
+        }
+
+        return config('data.name_mapping_strategy.output');
+    }
+
+    /**
+     * @param array<PhpAttributeNode> $mapOutputNodes
+     * @param array<PhpAttributeNode> $mapNodes
+     */
+    protected function extractMapperFromAttributes(array $mapOutputNodes, array $mapNodes): mixed
+    {
+        if (! empty($mapOutputNodes)) {
+            return $mapOutputNodes[0]->getArgument('output');
+        }
+
+        if (! empty($mapNodes)) {
+            return $mapNodes[0]->getArgument('output') ?? $mapNodes[0]->getArgument('input');
+        }
+
+        return null;
+    }
+
+    protected function applyOutputMapper(mixed $value, string $propertyName): string|int
+    {
+        if ($value instanceof NameMapper) {
+            return $value->map($propertyName);
+        }
+
+        if (is_string($value) && is_subclass_of($value, NameMapper::class)) {
+            return app($value)->map($propertyName);
+        }
+
+        return $value;
     }
 
     protected function shouldHideReference(

--- a/src/LaravelData/ClassPropertyProcessors/DataClassPropertyProcessor.php
+++ b/src/LaravelData/ClassPropertyProcessors/DataClassPropertyProcessor.php
@@ -4,9 +4,6 @@ namespace Spatie\LaravelTypeScriptTransformer\LaravelData\ClassPropertyProcessor
 
 use PHPStan\PhpDocParser\Ast\Type\TypeNode;
 use Spatie\LaravelData\Attributes\Hidden as DataHidden;
-use Spatie\LaravelData\Attributes\MapName;
-use Spatie\LaravelData\Attributes\MapOutputName;
-use Spatie\LaravelData\Mappers\NameMapper;
 use Spatie\LaravelData\Optional;
 use Spatie\LaravelData\Support\DataConfig;
 use Spatie\TypeScriptTransformer\Attributes\Hidden;
@@ -49,27 +46,10 @@ class DataClassPropertyProcessor implements ClassPropertyProcessor
             return null;
         }
 
-        $propertyName = $phpPropertyNode->getName();
+        $outputMappedName = $this->resolveOutputMappedName($phpPropertyNode);
 
-        $mapOutputNodes = $phpPropertyNode->getAttributes(MapOutputName::class);
-        $mapNodes = $phpPropertyNode->getAttributes(MapName::class);
-
-        if (empty($mapOutputNodes) && empty($mapNodes)) {
-            $classNode = $phpPropertyNode->getDeclaringClass();
-            $mapOutputNodes = $classNode->getAttributes(MapOutputName::class);
-            $mapNodes = $classNode->getAttributes(MapName::class);
-        }
-
-        if (! empty($mapOutputNodes)) {
-            $property->name = new TypeScriptIdentifier(
-                $this->resolveOutputName($mapOutputNodes[0]->getArgument('output'), $propertyName)
-            );
-        }
-
-        if (! empty($mapNodes)) {
-            $property->name = new TypeScriptIdentifier(
-                $this->resolveOutputName($mapNodes[0]->getArgument('output') ?? $mapNodes[0]->getArgument('input'), $propertyName)
-            );
+        if ($outputMappedName !== null) {
+            $property->name = new TypeScriptIdentifier($outputMappedName);
         }
 
         if (! $property->type instanceof TypeScriptUnion) {
@@ -99,17 +79,14 @@ class DataClassPropertyProcessor implements ClassPropertyProcessor
         return $property;
     }
 
-    protected function resolveOutputName(mixed $value, string $propertyName): string|int
+    protected function resolveOutputMappedName(PhpPropertyNode $phpPropertyNode): string|int|null
     {
-        if ($value instanceof NameMapper) {
-            return $value->map($propertyName);
-        }
+        $className = $phpPropertyNode->getDeclaringClass()->reflection->getName();
+        $propertyName = $phpPropertyNode->getName();
 
-        if (is_string($value) && class_exists($value) && is_subclass_of($value, NameMapper::class)) {
-            return (new $value())->map($propertyName);
-        }
+        $dataProperty = $this->dataConfig->getDataClass($className)->properties[$propertyName] ?? null;
 
-        return $value;
+        return $dataProperty?->outputMappedName;
     }
 
     protected function shouldHideReference(

--- a/src/LaravelData/Transformers/DataClassTransformer.php
+++ b/src/LaravelData/Transformers/DataClassTransformer.php
@@ -6,30 +6,19 @@ use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
 use Spatie\LaravelData\Contracts\BaseData;
 use Spatie\LaravelData\DataCollection;
-use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelTypeScriptTransformer\LaravelData\ClassPropertyProcessors\DataClassPropertyProcessor;
-use Spatie\TypeScriptTransformer\Actions\TranspilePhpStanTypeToTypeScriptNodeAction;
-use Spatie\TypeScriptTransformer\Actions\TranspilePhpTypeNodeToTypeScriptNodeAction;
 use Spatie\TypeScriptTransformer\ClassPropertyProcessors\FixArrayLikeStructuresClassPropertyProcessor;
 use Spatie\TypeScriptTransformer\PhpNodes\PhpClassNode;
 use Spatie\TypeScriptTransformer\Transformers\ClassTransformer;
-use Spatie\TypeScriptTransformer\TypeResolvers\DocTypeResolver;
 
 class DataClassTransformer extends ClassTransformer
 {
-    protected DataConfig $dataConfig;
-
     public function __construct(
         protected array $customLazyTypes = [],
         protected array $customDataCollections = [],
         protected bool $nullableAsOptional = false,
-        DocTypeResolver $docTypeResolver = new DocTypeResolver(),
-        TranspilePhpStanTypeToTypeScriptNodeAction $transpilePhpStanTypeToTypeScriptTypeAction = new TranspilePhpStanTypeToTypeScriptNodeAction(),
-        TranspilePhpTypeNodeToTypeScriptNodeAction $transpilePhpTypeNodeToTypeScriptTypeAction = new TranspilePhpTypeNodeToTypeScriptNodeAction(),
     ) {
-        $this->dataConfig = app(DataConfig::class);
-
-        parent::__construct($docTypeResolver, $transpilePhpStanTypeToTypeScriptTypeAction, $transpilePhpTypeNodeToTypeScriptTypeAction);
+        parent::__construct();
     }
 
     protected function shouldTransform(PhpClassNode $phpClassNode): bool
@@ -41,7 +30,6 @@ class DataClassTransformer extends ClassTransformer
     {
         return [
             new DataClassPropertyProcessor(
-                $this->dataConfig,
                 $this->customLazyTypes,
                 $this->nullableAsOptional,
             ),

--- a/src/LaravelData/Transformers/DataClassTransformer.php
+++ b/src/LaravelData/Transformers/DataClassTransformer.php
@@ -7,9 +7,12 @@ use Illuminate\Support\Collection;
 use Spatie\LaravelData\Contracts\BaseData;
 use Spatie\LaravelData\DataCollection;
 use Spatie\LaravelTypeScriptTransformer\LaravelData\ClassPropertyProcessors\DataClassPropertyProcessor;
+use Spatie\TypeScriptTransformer\Actions\TranspilePhpStanTypeToTypeScriptNodeAction;
+use Spatie\TypeScriptTransformer\Actions\TranspilePhpTypeNodeToTypeScriptNodeAction;
 use Spatie\TypeScriptTransformer\ClassPropertyProcessors\FixArrayLikeStructuresClassPropertyProcessor;
 use Spatie\TypeScriptTransformer\PhpNodes\PhpClassNode;
 use Spatie\TypeScriptTransformer\Transformers\ClassTransformer;
+use Spatie\TypeScriptTransformer\TypeResolvers\DocTypeResolver;
 
 class DataClassTransformer extends ClassTransformer
 {
@@ -17,8 +20,11 @@ class DataClassTransformer extends ClassTransformer
         protected array $customLazyTypes = [],
         protected array $customDataCollections = [],
         protected bool $nullableAsOptional = false,
+        DocTypeResolver $docTypeResolver = new DocTypeResolver(),
+        TranspilePhpStanTypeToTypeScriptNodeAction $transpilePhpStanTypeToTypeScriptTypeAction = new TranspilePhpStanTypeToTypeScriptNodeAction(),
+        TranspilePhpTypeNodeToTypeScriptNodeAction $transpilePhpTypeNodeToTypeScriptTypeAction = new TranspilePhpTypeNodeToTypeScriptNodeAction(),
     ) {
-        parent::__construct();
+        parent::__construct($docTypeResolver, $transpilePhpStanTypeToTypeScriptTypeAction, $transpilePhpTypeNodeToTypeScriptTypeAction);
     }
 
     protected function shouldTransform(PhpClassNode $phpClassNode): bool

--- a/tests/.pest/snapshots/LaravelData/DataClassTransformerTest/it_respects_the_global_name__mapping__strategy_output_config.snap
+++ b/tests/.pest/snapshots/LaravelData/DataClassTransformerTest/it_respects_the_global_name__mapping__strategy_output_config.snap
@@ -1,0 +1,4 @@
+type DataWithoutAttributes = {
+first_name: string,
+last_name: string,
+};

--- a/tests/FakeClasses/DataWithoutAttributes.php
+++ b/tests/FakeClasses/DataWithoutAttributes.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\LaravelTypeScriptTransformer\Tests\FakeClasses;
+
+use Spatie\LaravelData\Data;
+
+class DataWithoutAttributes extends Data
+{
+    public function __construct(
+        public string $firstName,
+        public string $lastName,
+    ) {
+    }
+}

--- a/tests/LaravelData/DataClassTransformerTest.php
+++ b/tests/LaravelData/DataClassTransformerTest.php
@@ -1,9 +1,12 @@
 <?php
 
+use Spatie\LaravelData\Mappers\SnakeCaseMapper;
+use Spatie\LaravelData\Support\DataConfig;
 use Spatie\LaravelTypeScriptTransformer\LaravelData\Transformers\DataClassTransformer;
 use Spatie\LaravelTypeScriptTransformer\Tests\FakeClasses\CustomLazy;
 use Spatie\LaravelTypeScriptTransformer\Tests\FakeClasses\DataWithAttributes;
 use Spatie\LaravelTypeScriptTransformer\Tests\FakeClasses\DataWithClassMapper;
+use Spatie\LaravelTypeScriptTransformer\Tests\FakeClasses\DataWithoutAttributes;
 use Spatie\TypeScriptTransformer\Data\TransformationContext;
 use Spatie\TypeScriptTransformer\Data\WritingContext;
 use Spatie\TypeScriptTransformer\PhpNodes\PhpClassNode;
@@ -45,6 +48,15 @@ it('transforms a data class with a class-level mapper', function () {
 
 it('converts nullable properties to optional when configured', function () {
     $output = renderDataClass(DataWithAttributes::class, nullableAsOptional: true);
+
+    expect($output)->toMatchSnapshot();
+});
+
+it('respects the global name_mapping_strategy.output config', function () {
+    config()->set('data.name_mapping_strategy.output', SnakeCaseMapper::class);
+    app()->forgetInstance(DataConfig::class);
+
+    $output = renderDataClass(DataWithoutAttributes::class);
 
     expect($output)->toMatchSnapshot();
 });


### PR DESCRIPTION
## Summary

Fixes #77.

In v3 the `DataClassPropertyProcessor` only renamed properties when it found a `MapName`/`MapOutputName` attribute on the property or class. The global `data.name_mapping_strategy.output` config (which laravel-data resolves into `DataProperty::\$outputMappedName` via `NameMappersResolver`) was silently ignored, so projects relying on the global mapper saw camelCase keys after upgrading.

The processor now resolves the output name through `DataConfig::getDataClass()`, which is the single source that already accounts for:

1. Global `data.name_mapping_strategy.output`.
2. Class-level `MapName` / `MapOutputName` attributes.
3. Property-level `MapName` / `MapOutputName` attributes.

The manual attribute walking (and `resolveOutputName()` helper) is removed, and a regression test sets the global config in the test environment to assert that property keys are snake_cased without any attribute being present on the data class.