### PR TITLE
Fix route() helper producing // for root route

### DIFF
--- a/src/Actions/ResolveRouteCollectionAction.php
+++ b/src/Actions/ResolveRouteCollectionAction.php
@@ -117,6 +117,6 @@ class ResolveRouteCollectionAction
 
     protected function resolveUrl(Route $route): string
     {
-        return str_replace('?}', '}', $route->getDomain().$route->uri);
+        return str_replace('?}', '}', $route->getDomain().ltrim($route->uri, '/'));
     }
 }

--- a/tests/.pest/snapshots/TransformedProviders/LaravelRouteTransformedProviderTest/it_generates_correct_TypeScript_output_for_named_routes.snap
+++ b/tests/.pest/snapshots/TransformedProviders/LaravelRouteTransformedProviderTest/it_generates_correct_TypeScript_output_for_named_routes.snap
@@ -52,7 +52,7 @@ const routes = {
     "resource.edit": "resource/{resource}/edit",
     "resource.update": "resource/{resource}",
     "resource.destroy": "resource/{resource}",
-    "home": "/",
+    "home": "",
     "pricing": "pricing",
     "blog": "blog",
     "blog.show": "blog/{slug}",

--- a/tests/Actions/ResolveRouteCollectionActionTest.php
+++ b/tests/Actions/ResolveRouteCollectionActionTest.php
@@ -34,6 +34,16 @@ it('can resolve all possible routes', function (Closure $route, Closure $expecta
             expect($routes->closures['Closure(simple)']->methods)->toBe(['GET', 'HEAD']);
         },
     ];
+    yield 'root closure' => [
+        fn (Router $router) => $router->get('/', fn () => 'home'),
+        function (RouteCollection $routes) {
+            expect($routes->controllers)->toBeEmpty();
+            expect($routes->closures)->toHaveCount(1);
+
+            expect($routes->closures['Closure(/)']->url)->toBe('');
+            expect($routes->closures['Closure(/)']->methods)->toBe(['GET', 'HEAD']);
+        },
+    ];
     yield 'controller action' => [
         fn (Router $router) => $router->get('action', [ResourceController::class, 'update']),
         function (RouteCollection $routes) {


### PR DESCRIPTION
## Summary

Fixes #75. The generated `route()` helper produced `//` (double slash) when called for the root route (`Route::get('/')`).

Laravel's `$route->uri` returns `/` literally for the root route but returns paths without a leading slash for every other route. The runtime helper template then does `'/' + routes[name]`, so `'/' + '/'` becomes `//`.

## Fix

`ltrim($route->uri, '/')` in `ResolveRouteCollectionAction::resolveUrl()` so the routes map is consistent. The root route now stores `""` and the runtime concatenation produces `/`. Other routes are unaffected because they never had a leading slash to begin with.

- `routes['home'] === ''` -> `'/' + '' === '/'`
- `routes['help.index'] === 'help'` -> `'/' + 'help' === '/help'` (unchanged)