### PR TITLE
Narrow controller method type and prioritize HTTP methods

### DIFF
--- a/src/Actions/GenerateControllerSupportAction.php
+++ b/src/Actions/GenerateControllerSupportAction.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LaravelTypeScriptTransformer\Actions;
 
+use InvalidArgumentException;
 use Spatie\LaravelTypeScriptTransformer\References\LaravelControllerReference;
 use Spatie\TypeScriptTransformer\Transformed\Transformed;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptAlias;
@@ -14,6 +15,7 @@ use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptGeneric;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptGenericTypeParameter;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptIdentifier;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptIntersection;
+use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptLiteral;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptMappedType;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptNull;
 use Spatie\TypeScriptTransformer\TypeScriptNodes\TypeScriptNumber;
@@ -31,12 +33,25 @@ class GenerateControllerSupportAction
     /** @var ?array<Transformed> */
     protected static ?array $cachedSupport = null;
 
-    /** @return array<Transformed> */
-    public function execute(): array
+    /**
+     * @param array<int, string> $httpMethods
+     *
+     * @return array<Transformed>
+     */
+    public function execute(array $httpMethods = ['get', 'post', 'put', 'patch', 'delete']): array
     {
+        if (empty($httpMethods)) {
+            throw new InvalidArgumentException('At least one HTTP method must be configured.');
+        }
+
         if (static::$cachedSupport !== null) {
             return static::$cachedSupport;
         }
+
+        $methodType = new TypeScriptUnion(array_map(
+            fn (string $method) => new TypeScriptLiteral(strtolower($method)),
+            $httpMethods,
+        ));
 
         return static::$cachedSupport = [
             new Transformed(
@@ -57,7 +72,7 @@ class GenerateControllerSupportAction
                     'RouteDefinition',
                     new TypeScriptObject([
                         new TypeScriptProperty('url', new TypeScriptString()),
-                        new TypeScriptProperty('method', new TypeScriptString()),
+                        new TypeScriptProperty('method', $methodType),
                     ])
                 ),
                 LaravelControllerReference::supportItem('RouteDefinition'),
@@ -106,7 +121,7 @@ class GenerateControllerSupportAction
                 new TypeScriptAlias(
                     'MethodRoute',
                     new TypeScriptObject([
-                        new TypeScriptProperty('method', new TypeScriptString()),
+                        new TypeScriptProperty('method', $methodType),
                         new TypeScriptProperty('url', new TypeScriptString()),
                     ])
                 ),

--- a/src/TransformedProviders/LaravelControllerTransformedProvider.php
+++ b/src/TransformedProviders/LaravelControllerTransformedProvider.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\LaravelTypeScriptTransformer\TransformedProviders;
 
-use Illuminate\Support\Arr;
 use Spatie\LaravelTypeScriptTransformer\ActionNameResolvers\ActionNameResolver;
 use Spatie\LaravelTypeScriptTransformer\ActionNameResolvers\DefaultActionNameResolver;
 use Spatie\LaravelTypeScriptTransformer\Actions\GenerateControllerSupportAction;
@@ -53,6 +52,7 @@ class LaravelControllerTransformedProvider extends LaravelRouterTransformedProvi
     /**
      * @param array<RouteFilter> $filters
      * @param array<string>|null $routeDirectories
+     * @param array<int, string> $httpMethodsPriority
      */
     public function __construct(
         protected string $location = 'controllers',
@@ -62,7 +62,10 @@ class LaravelControllerTransformedProvider extends LaravelRouterTransformedProvi
         ?array $routeDirectories = null,
         protected LaravelControllersCollection $controllersCollection = new LaravelControllersCollection(),
         protected GenerateControllerSupportAction $generateSupportAction = new GenerateControllerSupportAction(),
+        protected array $httpMethodsPriority = ['get', 'post', 'put', 'patch', 'delete'],
     ) {
+        $this->httpMethodsPriority = array_map('strtolower', $this->httpMethodsPriority);
+
         parent::__construct(
             resolveRouteCollectionAction: $resolveRouteCollectionAction,
             includeRouteClosures: false,
@@ -89,7 +92,7 @@ class LaravelControllerTransformedProvider extends LaravelRouterTransformedProvi
     /** @return array<Transformed> */
     protected function resolveSupport(): array
     {
-        return $this->generateSupportAction->execute();
+        return $this->generateSupportAction->execute($this->httpMethodsPriority);
     }
 
     /** @return array<Transformed> */
@@ -231,22 +234,10 @@ class LaravelControllerTransformedProvider extends LaravelRouterTransformedProvi
 
     protected function buildActionCallNode(RouteControllerAction $action): TypeScriptNode
     {
-        $methodPriorities = [
-            'get' => 0,
-            'post' => 1,
-            'put' => 2,
-            'patch' => 3,
-            'delete' => 4,
-            'head' => 5,
-            'options' => 6,
-        ];
-
-        $methods = array_map(
-            fn (string $method) => strtolower($method),
-            $action->methods,
-        );
-
-        $methods = Arr::sort($methods, fn (string $method) => $methodPriorities[$method]);
+        $methods = array_values(array_intersect(
+            $this->httpMethodsPriority,
+            array_map('strtolower', $action->methods),
+        ));
 
         $methodRoutes = new TypeScriptArrayExpression(array_map(
             fn (string $method) => new TypeScriptRaw("{ method: '{$method}', url: '{$action->url}' }"),

--- a/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_generates_correct_TypeScript_output_for_controllers.snap
+++ b/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_generates_correct_TypeScript_output_for_controllers.snap
@@ -1,18 +1,18 @@
-export const InvokableController = createActionWithMethods([{ method: 'get', url: 'invokable' }, { method: 'head', url: 'invokable' }])
+export const InvokableController = createActionWithMethods([{ method: 'get', url: 'invokable' }])
 export namespace InvokableController {
 export type Request = object;
 export type Response = object;
 }
 export const ResourceController = {
-index: createActionWithMethods([{ method: 'get', url: 'resource' }, { method: 'head', url: 'resource' }]),
-create: createActionWithMethods([{ method: 'get', url: 'resource/create' }, { method: 'head', url: 'resource/create' }]),
+index: createActionWithMethods([{ method: 'get', url: 'resource' }]),
+create: createActionWithMethods([{ method: 'get', url: 'resource/create' }]),
 store: createActionWithMethods([{ method: 'post', url: 'resource' }]),
 show: createActionWithMethods<{
 resource: string | number,
-}>([{ method: 'get', url: 'resource/{resource}' }, { method: 'head', url: 'resource/{resource}' }]),
+}>([{ method: 'get', url: 'resource/{resource}' }]),
 edit: createActionWithMethods<{
 resource: string | number,
-}>([{ method: 'get', url: 'resource/{resource}/edit' }, { method: 'head', url: 'resource/{resource}/edit' }]),
+}>([{ method: 'get', url: 'resource/{resource}/edit' }]),
 update: createActionWithMethods<{
 resource: string | number,
 }>([{ method: 'put', url: 'resource/{resource}' }, { method: 'patch', url: 'resource/{resource}' }]),

--- a/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_handles_optional_route_parameters.snap
+++ b/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_handles_optional_route_parameters.snap
@@ -2,7 +2,7 @@ export const TypedController = {
 returnsPhpType: createActionWithMethods<{
 user: string | number,
 slug?: string | number,
-}>([{ method: 'get', url: 'users/{user}/{slug}' }, { method: 'head', url: 'users/{user}/{slug}' }]),
+}>([{ method: 'get', url: 'users/{user}/{slug}' }]),
 } as const
 export namespace TypedController {
 export namespace returnsPhpType {

--- a/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_includes_type_parameters_when_action_has_route_parameters.snap
+++ b/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_includes_type_parameters_when_action_has_route_parameters.snap
@@ -1,7 +1,7 @@
 export const TypedController = {
 returnsPhpType: createActionWithMethods<{
 user: string | number,
-}>([{ method: 'get', url: 'users/{user}' }, { method: 'head', url: 'users/{user}' }]),
+}>([{ method: 'get', url: 'users/{user}' }]),
 } as const
 export namespace TypedController {
 export namespace returnsPhpType {

--- a/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_omits_type_parameters_when_action_has_no_route_parameters.snap
+++ b/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_omits_type_parameters_when_action_has_no_route_parameters.snap
@@ -1,5 +1,5 @@
 export const TypedController = {
-returnsPhpType: createActionWithMethods([{ method: 'get', url: 'simple' }, { method: 'head', url: 'simple' }]),
+returnsPhpType: createActionWithMethods([{ method: 'get', url: 'simple' }]),
 } as const
 export namespace TypedController {
 export namespace returnsPhpType {

--- a/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_resolves_array_shape_return_types.snap
+++ b/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_resolves_array_shape_return_types.snap
@@ -1,5 +1,5 @@
 export const TypedController = {
-returnsArrayShape: createActionWithMethods([{ method: 'get', url: 'shaped' }, { method: 'head', url: 'shaped' }]),
+returnsArrayShape: createActionWithMethods([{ method: 'get', url: 'shaped' }]),
 } as const
 export namespace TypedController {
 export namespace returnsArrayShape {

--- a/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_resolves_native_PHP_return_types.snap
+++ b/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_resolves_native_PHP_return_types.snap
@@ -1,5 +1,5 @@
 export const TypedController = {
-returnsPhpType: createActionWithMethods([{ method: 'get', url: 'typed' }, { method: 'head', url: 'typed' }]),
+returnsPhpType: createActionWithMethods([{ method: 'get', url: 'typed' }]),
 } as const
 export namespace TypedController {
 export namespace returnsPhpType {

--- a/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_resolves_void_return_type_as_object.snap
+++ b/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_resolves_void_return_type_as_object.snap
@@ -1,5 +1,5 @@
 export const TypedController = {
-returnsVoid: createActionWithMethods([{ method: 'get', url: 'void' }, { method: 'head', url: 'void' }]),
+returnsVoid: createActionWithMethods([{ method: 'get', url: 'void' }]),
 } as const
 export namespace TypedController {
 export namespace returnsVoid {

--- a/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_sorts_HTTP_methods_in_correct_order.snap
+++ b/tests/.pest/snapshots/TransformedProviders/LaravelControllerTransformedProviderTest/it_sorts_HTTP_methods_in_correct_order.snap
@@ -1,5 +1,5 @@
 export const TypedController = {
-returnsPhpType: createActionWithMethods([{ method: 'get', url: 'multi' }, { method: 'post', url: 'multi' }, { method: 'delete', url: 'multi' }, { method: 'head', url: 'multi' }]),
+returnsPhpType: createActionWithMethods([{ method: 'get', url: 'multi' }, { method: 'post', url: 'multi' }, { method: 'delete', url: 'multi' }]),
 } as const
 export namespace TypedController {
 export namespace returnsPhpType {

--- a/tests/TransformedProviders/LaravelControllerTransformedProviderTest.php
+++ b/tests/TransformedProviders/LaravelControllerTransformedProviderTest.php
@@ -84,14 +84,14 @@ it('includes type parameters when action has route parameters', function () {
     expect(transformControllers())->toMatchSnapshot();
 });
 
-function transformControllers(): string
+function transformControllers(array $httpMethods = ['get', 'post', 'put', 'patch', 'delete']): string
 {
     $provider = new LaravelControllerTransformedProvider(
         actionNameResolver: new StrippedActionNameResolver([
             'Spatie\LaravelTypeScriptTransformer\Tests\FakeClasses' => null,
         ]),
         generateSupportAction: new class extends GenerateControllerSupportAction {
-            public function execute(): array
+            public function execute(array $httpMethods = []): array
             {
                 return [
                     new Transformed(
@@ -102,7 +102,8 @@ function transformControllers(): string
                     ),
                 ];
             }
-        }
+        },
+        httpMethodsPriority: $httpMethods,
     );
 
     $provider->setPhpNodeCollection(new PhpNodeCollection());


### PR DESCRIPTION
## Summary

Addresses #76. Two related changes that make the generated controller output directly usable with libraries like Inertia that expect `'get' | 'post' | 'put' | 'patch' | 'delete'` rather than `string`.

- New `httpMethodsPriority` constructor argument on `LaravelControllerTransformedProvider`. The list determines which HTTP methods are emitted per route AND in what order. Methods absent from the list are filtered out.
- The same list drives the type of `method` on `RouteDefinition` and `MethodRoute`, which now resolves to a literal union instead of `string`.
- Default is `['get', 'post', 'put', 'patch', 'delete']`, so HEAD and OPTIONS (which Laravel auto-registers for every GET route) are dropped from the output by default.
- `GenerateControllerSupportAction::execute()` accepts the list as an argument and throws on an empty list, since an empty union would be invalid TypeScript.

## Notes

This changes the default output: HEAD entries no longer appear next to GET. Anyone who actually relied on those can pass a custom list including `'head'`.