### PR TITLE
Fix provider config file detection in install command

### DIFF
--- a/src/Commands/InstallTypeScriptTransformerCommand.php
+++ b/src/Commands/InstallTypeScriptTransformerCommand.php
@@ -46,7 +46,7 @@ class InstallTypeScriptTransformerCommand extends Command
 
     protected function registerServiceProvider(string $namespace): void
     {
-        $configFile = version_compare($this->laravel->version(), '11.0.0', '>=') ?
+        $configFile = file_exists(base_path('bootstrap/providers.php')) ?
             base_path('bootstrap/providers.php') :
             config_path('app.php');
 


### PR DESCRIPTION
The `php artisan typescript:install` command wasn't working for clients that created their repo before V11 then upgraded because the `bootstrap/providers.php` file wont exist.