### PR TITLE
Fix silent failure registering the service provider in typescript:install

### DIFF
--- a/src/Commands/InstallTypeScriptTransformerCommand.php
+++ b/src/Commands/InstallTypeScriptTransformerCommand.php
@@ -25,7 +25,7 @@ class InstallTypeScriptTransformerCommand extends Command
 
     protected function registerServiceProvider(): void
     {
-        $providersPath = $this->laravel->getBootstrapProvidersPath();
+        $providersPath = base_path('bootstrap/providers.php');
 
         $contents = file_exists($providersPath) ? file_get_contents($providersPath) : '';
 

--- a/src/Commands/InstallTypeScriptTransformerCommand.php
+++ b/src/Commands/InstallTypeScriptTransformerCommand.php
@@ -3,67 +3,47 @@
 namespace Spatie\LaravelTypeScriptTransformer\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 
-/**
- * @note Taken from the Laravel Horizon package
- */
 class InstallTypeScriptTransformerCommand extends Command
 {
     public $signature = 'typescript:install';
 
     public $description = 'Installs TypeScript transformer within your Laravel application.';
 
+    protected string $provider = 'App\Providers\TypeScriptTransformerServiceProvider';
+
     public function handle(): void
     {
         $this->comment('Publishing TypeScript Transformer Service Provider...');
         $this->callSilent('vendor:publish', ['--tag' => 'typescript-transformer-provider']);
-
-        $namespace = Str::replaceLast('\\', '', $this->laravel->getNamespace());
-
-        $this->installServiceProvider($namespace);
-        $this->registerServiceProvider($namespace);
-    }
-
-    protected function installServiceProvider(string $namespace): void
-    {
-        $serviceProviderPath = app_path('Providers/TypeScriptTransformerServiceProvider.php');
-
-        if (file_exists($serviceProviderPath)) {
-            $this->info('TypeScript Transformer Service Provider already installed.');
-
-            return;
-        }
-
-        file_put_contents($serviceProviderPath, str_replace(
-            "namespace App\Providers;",
-            "namespace {$namespace}\Providers;",
-            file_get_contents($serviceProviderPath)
-        ));
-
         $this->info('TypeScript Transformer Service Provider installed.');
+
+        $this->registerServiceProvider();
     }
 
-    protected function registerServiceProvider(string $namespace): void
+    protected function registerServiceProvider(): void
     {
-        $configFile = file_exists(base_path('bootstrap/providers.php')) ?
-            base_path('bootstrap/providers.php') :
-            config_path('app.php');
+        $providersPath = $this->laravel->getBootstrapProvidersPath();
 
-        $appConfig = file_get_contents($configFile);
+        $contents = file_exists($providersPath) ? file_get_contents($providersPath) : '';
 
-        if (Str::contains($appConfig, $namespace.'\\Providers\\TypeScriptTransformerServiceProvider::class')) {
+        if (Str::contains($contents, 'TypeScriptTransformerServiceProvider')) {
             $this->info('TypeScript Transformer Service Provider already registered.');
 
             return;
         }
 
-        file_put_contents($configFile, str_replace(
-            "{$namespace}\\Providers\AppServiceProvider::class,".PHP_EOL,
-            "{$namespace}\\Providers\AppServiceProvider::class,".PHP_EOL."    {$namespace}\Providers\TypeScriptTransformerServiceProvider::class,".PHP_EOL,
-            $appConfig
-        ));
+        if (ServiceProvider::addProviderToBootstrapFile($this->provider, $providersPath)) {
+            $this->info('TypeScript Transformer Service Provider registered.');
 
-        $this->info('TypeScript Transformer Service Provider registered.');
+            return;
+        }
+
+        $this->error(
+            "Could not automatically register the TypeScript Transformer Service Provider. "
+            ."Please add `{$this->provider}::class` to your bootstrap/providers.php file manually."
+        );
     }
 }

--- a/src/Commands/TransformTypeScriptCommand.php
+++ b/src/Commands/TransformTypeScriptCommand.php
@@ -18,7 +18,7 @@ class TransformTypeScriptCommand extends Command
     public function handle(Runner $runner): int
     {
         if (! app()->has(TypeScriptTransformerConfig::class)) {
-            $this->error('Please, first publish the TypeScriptTransformerServiceProvider and configure it.');
+            $this->error('TypeScript Transformer is not configured. Run `php artisan typescript:install` first.');
 
             return self::FAILURE;
         }

--- a/tests/Commands/TransformTypeScriptCommandTest.php
+++ b/tests/Commands/TransformTypeScriptCommandTest.php
@@ -12,7 +12,7 @@ it('shows an error when the config is not published', function () {
     app()->forgetInstance(TypeScriptTransformerConfig::class);
 
     $this->artisan('typescript:transform')
-        ->expectsOutputToContain('Please, first publish the TypeScriptTransformerServiceProvider and configure it.')
+        ->expectsOutputToContain('TypeScript Transformer is not configured.')
         ->assertExitCode(1);
 });
 


### PR DESCRIPTION
Fixes #86.

`typescript:install` injected the service provider into `bootstrap/providers.php` with a `str_replace` anchored on a literal class string, so it silently did nothing (yet still reported success) whenever that file used import style short class names. It now uses Laravel's `ServiceProvider::addProviderToBootstrapFile()`, which evaluates the file instead of matching text and therefore handles every layout, and reports an honest error when registration is not possible. The misleading `typescript:transform` message now points users to `typescript:install`, and the now unreachable namespace rewriting was dropped to simplify the command.