### PR TITLE
Keep routes that share a controller in the route generator

### DIFF
--- a/src/Actions/ResolveRouteCollectionAction.php
+++ b/src/Actions/ResolveRouteCollectionAction.php
@@ -55,36 +55,19 @@ class ResolveRouteCollectionAction
                 continue;
             }
 
-            if ($route->getActionMethod() === $route->getControllerClass()) {
-                $controllers[$controllerClass] = new RouteController(
-                    class: $controllerClass,
-                    file: $controllerFile,
-                    invokable: true,
-                    actions: [
-                        '__invoke' => new RouteControllerAction(
-                            methodName: '__invoke',
-                            parameters: $this->resolveRouteParameters($route),
-                            methods: $route->methods,
-                            url: $this->resolveUrl($route),
-                            name: $route->getName(),
-                        ),
-                    ],
-                );
-
-                continue;
-            }
+            $invokable = $route->getActionMethod() === $route->getControllerClass();
 
             if (! array_key_exists($controllerClass, $controllers)) {
                 $controllers[$controllerClass] = new RouteController(
                     class: $controllerClass,
                     file: $controllerFile,
-                    invokable: false,
+                    invokable: $invokable,
                     actions: [],
                 );
             }
 
-            $controllers[$controllerClass]->actions[$route->getActionMethod()] = new RouteControllerAction(
-                methodName: $route->getActionMethod(),
+            $controllers[$controllerClass]->actions[] = new RouteControllerAction(
+                methodName: $invokable ? '__invoke' : $route->getActionMethod(),
                 parameters: $this->resolveRouteParameters($route),
                 methods: $route->methods,
                 url: $this->resolveUrl($route),

--- a/src/Routes/RouteController.php
+++ b/src/Routes/RouteController.php
@@ -4,7 +4,7 @@ namespace Spatie\LaravelTypeScriptTransformer\Routes;
 
 class RouteController
 {
-    /** @param array<string, RouteControllerAction> $actions */
+    /** @param array<int, RouteControllerAction> $actions */
     public function __construct(
         public string $class,
         public string $file,

--- a/src/TransformedProviders/LaravelRouteTransformedProvider.php
+++ b/src/TransformedProviders/LaravelRouteTransformedProvider.php
@@ -2,7 +2,6 @@
 
 namespace Spatie\LaravelTypeScriptTransformer\TransformedProviders;
 
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Spatie\LaravelTypeScriptTransformer\Actions\ResolveRouteCollectionAction;
 use Spatie\LaravelTypeScriptTransformer\References\LaravelRouteReference;
@@ -185,20 +184,8 @@ TS
     {
         return collect(array_merge($collection->controllers, $collection->closures))
             ->flatMap(function (RouteController|RouteClosure $entity) {
-                if ($entity instanceof RouteClosure && $entity->name) {
-                    return [$entity];
-                }
-
                 if ($entity instanceof RouteClosure) {
-                    return [];
-                }
-
-                if ($entity->invokable && ($action = Arr::first($entity->actions)) && $action->name) {
-                    return [$action];
-                }
-
-                if ($entity->invokable) {
-                    return [];
+                    return $entity->name ? [$entity] : [];
                 }
 
                 return collect($entity->actions)

--- a/tests/.pest/snapshots/TransformedProviders/LaravelRouteTransformedProviderTest/it_generates_correct_TypeScript_output_for_named_routes.snap
+++ b/tests/.pest/snapshots/TransformedProviders/LaravelRouteTransformedProviderTest/it_generates_correct_TypeScript_output_for_named_routes.snap
@@ -1,4 +1,6 @@
 type RouteParameters = {
+invokable: never,
+'resource.index': never,
 'resource.create': never,
 'resource.store': never,
 'resource.show': {
@@ -46,6 +48,8 @@ if (absolute) {
 return url;
 }
 const routes = {
+    "invokable": "invokable",
+    "resource.index": "resource",
     "resource.create": "resource/create",
     "resource.store": "resource",
     "resource.show": "resource/{resource}",

--- a/tests/Actions/ResolveRouteCollectionActionTest.php
+++ b/tests/Actions/ResolveRouteCollectionActionTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Illuminate\Routing\Router;
+use Illuminate\Support\Arr;
 use Spatie\LaravelTypeScriptTransformer\Actions\ResolveRouteCollectionAction;
 use Spatie\LaravelTypeScriptTransformer\RouteFilters\ControllerRouteFilter;
 use Spatie\LaravelTypeScriptTransformer\RouteFilters\NamedRouteFilter;
@@ -50,7 +51,7 @@ it('can resolve all possible routes', function (Closure $route, Closure $expecta
             expect($routes->controllers)->toHaveCount(1);
             expect($routes->closures)->toBeEmpty();
 
-            $actions = $routes->controllers[ResourceController::class]->actions;
+            $actions = Arr::keyBy($routes->controllers[ResourceController::class]->actions, 'methodName');
 
             expect($actions)->toHaveCount(1);
             expect($actions['update'])->toBeInstanceOf(RouteControllerAction::class);
@@ -74,7 +75,9 @@ it('can resolve all possible routes', function (Closure $route, Closure $expecta
             expect($controller->invokable)->toBeTrue();
             expect($controller->class)->toBe(InvokableController::class);
 
-            $action = $controller->actions['__invoke'];
+            expect($controller->actions)->toHaveCount(1);
+
+            $action = Arr::keyBy($controller->actions, 'methodName')['__invoke'];
             expect($action)->toBeInstanceOf(RouteControllerAction::class);
             expect($action->methodName)->toBe('__invoke');
             expect($action->url)->toBe('invokable');
@@ -96,6 +99,8 @@ it('can resolve all possible routes', function (Closure $route, Closure $expecta
             expect($controller->invokable)->toBeFalse();
             expect($controller->class)->toBe(ResourceController::class);
             expect($controller->actions)->toHaveCount(7);
+
+            $controller->actions = Arr::keyBy($controller->actions, 'methodName');
 
             expect($controller->actions['index'])->toBeInstanceOf(RouteControllerAction::class);
             expect($controller->actions['index']->methodName)->toBe('index');
@@ -210,9 +215,11 @@ it('can resolve all possible routes', function (Closure $route, Closure $expecta
             expect($routes->closures['Closure(simple)']->name)->toBe('simple');
 
             $invokableController = $routes->controllers[InvokableController::class];
-            expect($invokableController->actions['__invoke']->name)->toBe('invokable');
+            $invokableActions = Arr::keyBy($invokableController->actions, 'methodName');
+            expect($invokableActions['__invoke']->name)->toBe('invokable');
 
             $resourceController = $routes->controllers[ResourceController::class];
+            $resourceController->actions = Arr::keyBy($resourceController->actions, 'methodName');
 
             expect($resourceController->actions['index']->name)->toBe('resource.index');
             expect($resourceController->actions['show']->name)->toBe('resource.show');
@@ -221,6 +228,43 @@ it('can resolve all possible routes', function (Closure $route, Closure $expecta
             expect($resourceController->actions['store']->name)->toBe('resource.store');
             expect($resourceController->actions['edit']->name)->toBe('resource.edit');
             expect($resourceController->actions['destroy']->name)->toBe('resource.destroy');
+        },
+    ];
+    yield 'multiple routes sharing an invokable controller' => [
+        function (Router $router) {
+            $router->get('terms', InvokableController::class)->name('terms');
+            $router->get('privacy', InvokableController::class)->name('privacy');
+            $router->get('cookies', InvokableController::class)->name('cookies');
+        },
+        function (RouteCollection $routes) {
+            expect($routes->controllers)->toHaveCount(1);
+
+            $controller = $routes->controllers[InvokableController::class];
+
+            expect($controller->invokable)->toBeTrue();
+            expect($controller->actions)->toHaveCount(3);
+            expect(Arr::pluck($controller->actions, 'name'))
+                ->toBe(['terms', 'privacy', 'cookies']);
+            expect(Arr::pluck($controller->actions, 'url'))
+                ->toBe(['terms', 'privacy', 'cookies']);
+        },
+    ];
+    yield 'multiple routes sharing a controller method' => [
+        function (Router $router) {
+            $router->get('en/about', [ResourceController::class, 'show'])->name('en.about');
+            $router->get('nl/about', [ResourceController::class, 'show'])->name('nl.about');
+        },
+        function (RouteCollection $routes) {
+            expect($routes->controllers)->toHaveCount(1);
+
+            $controller = $routes->controllers[ResourceController::class];
+
+            expect($controller->invokable)->toBeFalse();
+            expect($controller->actions)->toHaveCount(2);
+            expect(Arr::pluck($controller->actions, 'methodName'))
+                ->toBe(['show', 'show']);
+            expect(Arr::pluck($controller->actions, 'name'))
+                ->toBe(['en.about', 'nl.about']);
         },
     ];
 });
@@ -261,7 +305,7 @@ it('can filter out certain routes', function (
                     ResourceController::class,
                     InvokableController::class,
                 ]);
-            expect($routes->controllers[ResourceController::class]->actions)
+            expect(Arr::keyBy($routes->controllers[ResourceController::class]->actions, 'methodName'))
                 ->toHaveCount(5)
                 ->toHaveKeys([
                     'show',
@@ -310,7 +354,7 @@ it('can filter out certain routes', function (
                     ResourceController::class,
                     InvokableController::class,
                 ]);
-            expect($routes->controllers[ResourceController::class]->actions)
+            expect(Arr::keyBy($routes->controllers[ResourceController::class]->actions, 'methodName'))
                 ->toHaveCount(5)
                 ->toHaveKeys([
                     'show',


### PR DESCRIPTION
Fixes #87.

The route generator indexed routes by controller identity (invokable class, or `class@method`), so any two routes pointing at the same endpoint overwrote each other and only the last one survived in the generated TypeScript. This silently dropped `Route::inertia()` pages and the per-locale routes registered by localized routing packages. `RouteController::$actions` is now a flat list of route bindings instead of a map keyed by method, and the resolver appends every route so the route helper emits all named routes. The controller provider needs no changes since it already re-keys actions by method name, collapsing shared methods to a single entry.